### PR TITLE
create_or_replace_view

### DIFF
--- a/lib/rails_sql_views/connection_adapters/abstract/schema_statements.rb
+++ b/lib/rails_sql_views/connection_adapters/abstract/schema_statements.rb
@@ -38,6 +38,10 @@ module RailsSqlViews
       # [<tt>:check_option</tt>]
       #   Specify restrictions for inserts or updates in updatable views. ANSI SQL 92 defines two check option
       #   values: CASCADED and LOCAL. See your database documentation for allowed values.
+      # [<tt>:force</tt>]
+      #   If true, explicitly drop the view before running the create query
+      # [<tt>:primary_key</tt>]
+      #   If present, create a primary key for the view using this value
       def create_view(name, select_query, options={})
         if supports_views?
           view_definition = ViewDefinition.new(self, select_query)
@@ -51,6 +55,38 @@ module RailsSqlViews
           end
 
           create_sql = "CREATE VIEW "
+          create_sql << "#{quote_table_name(name)} "
+          if supports_view_columns_definition? && !view_definition.to_sql.blank?
+            create_sql << "("
+            create_sql << view_definition.to_sql
+            create_sql << ") " 
+          end
+          create_sql << "AS #{view_definition.select_query}"
+          create_sql << " WITH #{options[:check_option]} CHECK OPTION" if options[:check_option]
+          execute create_sql
+        end
+
+        if options[:primary_key]
+          create_primary_key_for_view name, options[:primary_key]
+        end
+      end
+      
+      # Create or replace a view.
+      # The +options+ hash can include the following keys:
+      # [<tt>:check_option</tt>]
+      #   Specify restrictions for inserts or updates in updatable views. ANSI SQL 92 defines two check option
+      #   values: CASCADED and LOCAL. See your database documentation for allowed values.
+      # [<tt>:primary_key</tt>]
+      #   If present, create a primary key for the view using this value
+      def create_or_replace_view(name, select_query, options={})
+        if supports_views? && replaces_views?
+          view_definition = ViewDefinition.new(self, select_query)
+          
+          if block_given?
+            yield view_definition
+          end
+
+          create_sql = "CREATE OR REPLACE VIEW "
           create_sql << "#{quote_table_name(name)} "
           if supports_view_columns_definition? && !view_definition.to_sql.blank?
             create_sql << "("

--- a/lib/rails_sql_views/connection_adapters/abstract/schema_statements.rb
+++ b/lib/rails_sql_views/connection_adapters/abstract/schema_statements.rb
@@ -64,10 +64,10 @@ module RailsSqlViews
           create_sql << "AS #{view_definition.select_query}"
           create_sql << " WITH #{options[:check_option]} CHECK OPTION" if options[:check_option]
           execute create_sql
-        end
 
-        if options[:primary_key]
-          create_primary_key_for_view name, options[:primary_key]
+          if options[:primary_key]
+            create_primary_key_for_view name, options[:primary_key]
+          end
         end
       end
       
@@ -96,10 +96,10 @@ module RailsSqlViews
           create_sql << "AS #{view_definition.select_query}"
           create_sql << " WITH #{options[:check_option]} CHECK OPTION" if options[:check_option]
           execute create_sql
-        end
-
-        if options[:primary_key]
-          create_primary_key_for_view name, options[:primary_key]
+          
+          if options[:primary_key]
+            create_primary_key_for_view name, options[:primary_key]
+          end
         end
       end
 

--- a/lib/rails_sql_views/connection_adapters/abstract_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/abstract_adapter.rb
@@ -14,6 +14,11 @@ module RailsSqlViews
       def supports_views?
         return false
       end
+      
+      # Subclasses should override and return true if they support replacing views.
+      def replaces_views?
+        return false
+      end
 
       def disable_referential_integrity_with_views_excluded(&block)
         self.class.send(:alias_method, :original_tables_method, :tables)

--- a/lib/rails_sql_views/connection_adapters/mysql_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/mysql_adapter.rb
@@ -12,6 +12,11 @@ module RailsSqlViews
         true
       end
       
+      # Returns true as this adapter supports replacing views.
+      def replaces_views?
+        true
+      end
+      
       def base_tables(name = nil) #:nodoc:
         tables = []
         execute("SHOW FULL TABLES WHERE TABLE_TYPE='BASE TABLE'").each{|row| tables << row[0]}

--- a/lib/rails_sql_views/connection_adapters/oracle_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/oracle_adapter.rb
@@ -6,6 +6,11 @@ module RailsSqlViews
        true
      end
 
+     # Returns true as this adapter supports replacing views.
+     def replaces_views?
+       true
+     end
+
      def base_tables(name = nil) #:nodoc:
        tables = []
        execute("SELECT TABLE_NAME FROM USER_TABLES", name).each { |row| tables << row[0]  }

--- a/lib/rails_sql_views/connection_adapters/oracleenhanced_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/oracleenhanced_adapter.rb
@@ -10,6 +10,11 @@ module RailsSqlViews
         true
       end
       
+      # Returns true as this adapter supports replacing views.
+      def replaces_views?
+        true
+      end
+      
       def base_tables(name = nil) #:nodoc:
         tables = []
         cursor = execute("SELECT TABLE_NAME FROM ALL_TABLES WHERE owner = SYS_CONTEXT('userenv', 'current_schema') AND secondary = 'N'", name)

--- a/lib/rails_sql_views/connection_adapters/postgresql_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/postgresql_adapter.rb
@@ -9,6 +9,11 @@ module RailsSqlViews
         true
       end
       
+      # Returns true as this adapter supports replacing views.
+      def replaces_views?
+        true
+      end
+      
       def tables_with_views_included(name = nil)
         q = <<-SQL
         SELECT table_name, table_type

--- a/lib/rails_sql_views/migration/command_recorder.rb
+++ b/lib/rails_sql_views/migration/command_recorder.rb
@@ -5,6 +5,10 @@ module RailsSqlViews
           record(:create_view, args)
         end   
 
+        def create_or_replace_view(*args)
+          record(:create_or_replace_view, args)
+        end   
+
         def create_materialized_view(*args)
           record(:create_materialized_view, args)
         end  

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,4 +27,14 @@ class Test::Unit::TestCase
       v.column :address_id
     end
   end
+  def create_or_replace_people_view
+    ActiveRecord::Base.connection.create_or_replace_view(:v_people,
+        'select id, first_name, last_name, ssn, address_id from people') do |v|
+      v.column :id
+      v.column :f_name
+      v.column :l_name
+      v.column :social_security
+      v.column :address_id
+    end
+  end
 end


### PR DESCRIPTION
I've added this method in the simplest manner possible. Making it support SQL Server would require refactoring the schema_statements.rb file to allow each adapter to define its own syntax for this method. For it and SQLite, I simply marked it as not supporting this feature. I do not know for certain if the oc adapter supports this syntax (or more properly, if the versions of Oracle that work with it support it) and I did not look into that in any depth. Last time I saw oc adapter in production use, the version of Rails started with a 1.

I tried to run the tests, but then figured out very quickly that there was no oracle test set up. If you would like me to pursue that, I will.