### PR TITLE
Add support for SQLite3Adapter

### DIFF
--- a/lib/rails_sql_views/connection_adapters/sqlite3_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/sqlite3_adapter.rb
@@ -1,0 +1,62 @@
+module RailsSqlViews
+  module ConnectionAdapters
+    module SQLite3Adapter
+      def supports_views?
+        true
+      end
+
+      def tables(name = nil) #:nodoc:
+        sql = <<-SQL
+          SELECT name
+          FROM sqlite_master
+          WHERE (type = 'table' OR type = 'view') AND NOT name = 'sqlite_sequence'
+        SQL
+
+        execute(sql, name).map do |row|
+          row[0]
+        end
+      end
+
+      def base_tables(name = nil)
+        sql = <<-SQL
+          SELECT name
+          FROM sqlite_master
+          WHERE (type = 'table') AND NOT name = 'sqlite_sequence'
+        SQL
+
+        execute(sql, name).map do |row|
+          row[0]
+        end        
+      end
+      alias nonview_tables base_tables
+      
+      def views(name = nil)
+        sql = <<-SQL
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'view' AND NOT name = 'sqlite_sequence'
+        SQL
+
+        execute(sql, name).map do |row|
+          row[0]
+        end
+      end
+      
+      # Get the view select statement for the specified table.
+      def view_select_statement(view, name = nil)
+        sql = <<-SQL
+          SELECT sql
+          FROM sqlite_master
+          WHERE name = '#{view}' AND NOT name = 'sqlite_sequence'
+        SQL
+        
+        (select_value(sql, name).gsub("CREATE VIEW #{view} AS ", "")) or raise "No view called #{view} found"
+      end
+      
+      def supports_view_columns_definition?
+        false
+      end
+      
+    end
+  end
+end

--- a/lib/rails_sql_views/loader.rb
+++ b/lib/rails_sql_views/loader.rb
@@ -1,7 +1,7 @@
 
 module RailsSqlViews
   module Loader
-    SUPPORTED_ADAPTERS = %w( Mysql PostgreSQL SQLServer SQLite OracleEnhanced )
+    SUPPORTED_ADAPTERS = %w( Mysql PostgreSQL SQLServer SQLite SQLite3 OracleEnhanced )
 
     def self.load_extensions
       SUPPORTED_ADAPTERS.each do |db|


### PR DESCRIPTION
This appears to be all that is necessary to solve the "undefined method `base_tables'" problem you get if you use this gem with the sqlite3 gem. I assume there used to be an adapter called "SQLite" instead of "SQLite3" since there was already support in here for such a thing. I just copied that support to a new adapter module named "SQLite3" with the hopes that the internals would all work the same way.