### PR TITLE
Replace `alias_method_chain` with `Module.prepend`

### DIFF
--- a/lib/pmacs-rails_sql_views.rb
+++ b/lib/pmacs-rails_sql_views.rb
@@ -42,7 +42,7 @@ ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
 end
 
 ActiveRecord::SchemaDumper.class_eval do
-  include RailsSqlViews::SchemaDumper
+  prepend RailsSqlViews::SchemaDumper
 end
 
 RailsSqlViews::Loader.load_extensions

--- a/lib/rails_sql_views/connection_adapters/abstract_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/abstract_adapter.rb
@@ -1,10 +1,6 @@
 module RailsSqlViews
   module ConnectionAdapters
     module AbstractAdapter
-      def self.included(base)
-        base.alias_method_chain :disable_referential_integrity, :views_excluded
-      end
-
       # Subclasses should override and return true if they support views.
       def supports_materialized_views?
         return false
@@ -20,10 +16,10 @@ module RailsSqlViews
         return false
       end
 
-      def disable_referential_integrity_with_views_excluded(&block)
+      def disable_referential_integrity(&block)
         self.class.send(:alias_method, :original_tables_method, :tables)
         self.class.send(:alias_method, :tables, :base_tables)
-        disable_referential_integrity_without_views_excluded(&block)
+        super(&block)
       ensure
         self.class.send(:alias_method, :tables, :original_tables_method)
       end

--- a/lib/rails_sql_views/loader.rb
+++ b/lib/rails_sql_views/loader.rb
@@ -8,8 +8,8 @@ module RailsSqlViews
         if ActiveRecord::ConnectionAdapters.const_defined?("#{db}Adapter")
           require "rails_sql_views/connection_adapters/#{db.downcase}_adapter"
           ActiveRecord::ConnectionAdapters.const_get("#{db}Adapter").class_eval do
-            include RailsSqlViews::ConnectionAdapters::AbstractAdapter
-            include RailsSqlViews::ConnectionAdapters.const_get("#{db}Adapter")
+            prepend RailsSqlViews::ConnectionAdapters::AbstractAdapter
+            prepend RailsSqlViews::ConnectionAdapters.const_get("#{db}Adapter")
           end
         end
       end

--- a/lib/rails_sql_views/schema_dumper.rb
+++ b/lib/rails_sql_views/schema_dumper.rb
@@ -1,10 +1,6 @@
 module RailsSqlViews
   module SchemaDumper
     def self.included(base)
-      base.alias_method_chain :trailer, :views
-      base.alias_method_chain :dump, :views
-      base.alias_method_chain :tables, :views_excluded
-      
       # A list of views which should not be dumped to the schema. 
       # Acceptable values are strings as well as regexp.
       # This setting is only used if ActiveRecord::Base.schema_format == :ruby
@@ -18,13 +14,9 @@ module RailsSqlViews
       base.view_creation_order = []
     end
     
-    def trailer_with_views(stream)
-      # do nothing...we'll call this later
-    end
-    
     # Add views to the end of the dump stream
-    def dump_with_views(stream)
-      dump_without_views(stream)
+    def dump(stream)
+      super(stream)
       begin
         if @connection.supports_views?
           views(stream)
@@ -36,7 +28,7 @@ module RailsSqlViews
           raise e
         end
       end
-      trailer_without_views(stream)
+      trailer(stream)
       stream
     end
     
@@ -94,7 +86,7 @@ module RailsSqlViews
       stream
     end
 
-    def tables_with_views_excluded(stream)
+    def tables(stream)
       @connection.base_tables.sort.each do |tbl|
         next if [ActiveRecord::Migrator.schema_migrations_table_name, ignore_tables].flatten.any? do |ignored|
           case ignored


### PR DESCRIPTION
This replaces `alias_method_chain` with `Module.prepend`.

I should note that I didn't touch anything but the OEA module and this whole gem is feeling increasingly brittle. This will get our view-manipulating apps working on Rails 5.1, but I'm going to give a priority bump to our efforts to get off of this gem and onto something better.