### PR TITLE
update schema dumper

### DIFF
--- a/lib/rails_sql_views/schema_dumper.rb
+++ b/lib/rails_sql_views/schema_dumper.rb
@@ -17,7 +17,7 @@ module RailsSqlViews
     # Add views to the end of the dump stream
     def dump(stream)
       super(stream)
-      remove_trailing_end(stream)
+      remove_trailer(stream)
       begin
         if @connection.supports_views?
           views(stream)
@@ -101,7 +101,7 @@ module RailsSqlViews
       end
     end
 
-    def remove_trailing_end(stream)
+    def remove_trailer(stream)
       stream.sub!(/\s+?end\z/)
     end
   end

--- a/lib/rails_sql_views/schema_dumper.rb
+++ b/lib/rails_sql_views/schema_dumper.rb
@@ -17,6 +17,7 @@ module RailsSqlViews
     # Add views to the end of the dump stream
     def dump(stream)
       super(stream)
+      remove_trailing_end(stream)
       begin
         if @connection.supports_views?
           views(stream)
@@ -100,5 +101,8 @@ module RailsSqlViews
       end
     end
 
+    def remove_trailing_end(stream)
+      stream.sub!(/\s+?end\z/)
+    end
   end
 end

--- a/lib/rails_sql_views/schema_dumper.rb
+++ b/lib/rails_sql_views/schema_dumper.rb
@@ -102,7 +102,7 @@ module RailsSqlViews
     end
 
     def remove_trailer(stream)
-      stream.sub!(/\s+?end\z/)
+      stream.sub!(/\s*?end\z/)
     end
   end
 end


### PR DESCRIPTION
This is a first naive pass at correcting the double-end problem we have noticed in schema.rb dumps of legacy migrations that include views.