### PR TITLE
Update sqlite3_adapter for Rails 8

### DIFF
--- a/lib/rails_sql_views/connection_adapters/sqlite3_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/sqlite3_adapter.rb
@@ -13,7 +13,7 @@ module RailsSqlViews
         SQL
 
         execute(sql, name).map do |row|
-          row[0]
+          row['name']
         end
       end
       alias nonview_tables base_tables
@@ -26,7 +26,7 @@ module RailsSqlViews
         SQL
 
         execute(sql, name).map do |row|
-          row[0]
+          row['name']
         end
       end
 

--- a/lib/rails_sql_views/connection_adapters/sqlite3_adapter.rb
+++ b/lib/rails_sql_views/connection_adapters/sqlite3_adapter.rb
@@ -38,7 +38,7 @@ module RailsSqlViews
           WHERE name = '#{view}' AND NOT name = 'sqlite_sequence'
         SQL
 
-        (select_value(sql, name).gsub("CREATE VIEW #{view} AS ", "")) or raise "No view called #{view} found"
+        (select_value(sql, name).gsub(/CREATE VIEW "?#{view}"? AS /, "")) or raise "No view called #{view} found"
       end
 
       def supports_view_columns_definition?


### PR DESCRIPTION
I ran into this error when trying to run migrations locally:
```
** Invoke db:_dump (first_time)
** Execute db:_dump
** Invoke db:schema:dump (first_time)
** Invoke db:load_config 
** Execute db:schema:dump
bin/rails aborted!
ActiveRecord::StatementInvalid: Could not find table '' (ActiveRecord::StatementInvalid)
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/sqlite3_adapter.rb:517:in `table_structure'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/activerecord-8.0.2/lib/active_record/connection_adapters/abstract/schema_statements.rb:109:in `columns'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/activerecord-8.0.2/lib/active_record/schema_dumper.rb:159:in `table'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/pmacs-rails_sql_views-0.12.4/lib/rails_sql_views/schema_dumper.rb:101:in `block in tables'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/pmacs-rails_sql_views-0.12.4/lib/rails_sql_views/schema_dumper.rb:92:in `each'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/pmacs-rails_sql_views-0.12.4/lib/rails_sql_views/schema_dumper.rb:92:in `tables'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/pmacs-rails_sql_views-0.12.4/lib/rails_sql_views/schema_dumper.rb:21:in `dump'
~/.rbenv/versions/3.3.9/lib/ruby/gems/3.3.0/gems/activerecord-8.0.2/lib/active_record/schema_dumper.rb:46:in `block in dump'
...
```
After digging around a bit, I found out that sqlite3 was also affected by changes to `connection.execute`.

The PR also attempts to address this issue:
```
ActiveRecord::StatementInvalid: SQLite3::SQLException: near "CREATE": syntax error: (ActiveRecord::StatementInvalid)
CREATE VIEW "test_v" AS CREATE VIEW "test_v" AS       SELECT
...
```
This happened when trying to run dev/test migrations when a schema.rb file existed.
`CREATE VIEW ...` was duplicated because it wasn't stripped out by the `SQLite3Adapter#view_select_statement` method, because the method wasn't accounting for the double-quotes around the view name.
I was able to reproduce this in Rails 7.1 by running the `db:schema:load` task. So I think this bug already existed, but Rails 7.1 was re-running migrations instead of loading schema.rb.
